### PR TITLE
Bump plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
         </developer>
     </developers>
 
+    <prerequisites>
+        <maven>3.0.4</maven>
+    </prerequisites>
+
     <scm>
         <connection>scm:git:ssh://git@github.com/osiam/distribution.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/osiam/distribution.git</developerConnection>
@@ -246,7 +250,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.5.2</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                 </configuration>
@@ -283,7 +287,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.1</version>
+                        <version>2.8.2</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.apache.maven.wagon</groupId>


### PR DESCRIPTION
also add prerequisite on Maven 3.0.4